### PR TITLE
Specify namespace on soapbind:body when using rpc

### DIFF
--- a/src/WSDL/XML/XMLGenerator.php
+++ b/src/WSDL/XML/XMLGenerator.php
@@ -310,7 +310,8 @@ class XMLGenerator
 
         foreach ($this->_WSDLMethods as $method) {
             $soapBodyElement = $this->createElementWithAttributes('soap:body', array(
-                'use' => $this->_bindingStyle->bindingUse()
+                'use' => $this->_bindingStyle->bindingUse(),
+                'namespace' => $this->_targetNamespace
             ));
 
             $operationElement = $this->createElementWithAttributes('operation', array(

--- a/tests/src/WSDL/XML/XMLGeneratorTest.php
+++ b/tests/src/WSDL/XML/XMLGeneratorTest.php
@@ -121,6 +121,29 @@ class XMLGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertSelectCount('binding operation', 6, $this->_XML);
     }
 
+    public function shouldPutNamespaceOnSoapBindBody()
+    {
+        //given
+        $matcher = array(
+            'tag' => 'binding',
+            'ancestor' => array('tag' => 'definitions'),
+            'attributes' => array(
+                'name' => 'MockClassBinding',
+                'type' => "tns:MockClassPortType"
+            ),
+            'descendant' => array(
+                'tag' => 'body',
+                'attributes' => array(
+                    'use' => 'literal',
+                    'namespace' => $this->_targetNamespace
+                )
+            )
+        );
+
+        $this->assertTag($matcher, $this->_XML, '', false);
+        $this->assertSelectCount('binding body@namepsace', 12, $this->_XML);
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
When importing a WSDL, SoapUI would give a warning:

```
Thu May 22 16:03:55 EST 2014:WARN:missing namespace on soapbind:body for RPC request, using targetNamespace instead (BP violation)
```

This pull request places the namespace on the soapbind:body, and adds a corresponding test
