### PR TITLE
Generate complex array definitions that PHP SoapServer can use

### DIFF
--- a/src/WSDL/Parser/ParameterParser.php
+++ b/src/WSDL/Parser/ParameterParser.php
@@ -111,7 +111,7 @@ class ParameterParser
         if (!$this->isComplex()) {
             throw new ParameterParserException("This parameter is not complex type.");
         }
-        preg_match('#@className=(.+)#', $this->_parameter, $matches);
+        preg_match('#@className=(.*?)(?:\s|$)#', $this->_parameter, $matches);
         $className = $matches[1];
         $this->_type = str_replace('\\', '', $className);
         $wrapperParser = new WrapperParser($className);

--- a/src/WSDL/XML/Styles/Style.php
+++ b/src/WSDL/XML/Styles/Style.php
@@ -85,7 +85,8 @@ abstract class Style
         $typesComplex = new TypesComplex();
         $typesComplex
             ->setName('ArrayOf' . ucfirst($parameter->getName()))
-            ->setArrayType($type . $this->_getObjectName($parameter) . '[]');
+            ->setArrayType($type . $this->_getObjectName($parameter) . '[]')
+            ->setArrayTypeName(\WSDL\Utilities\Strings::depluralize($parameter->getName()));
 
         if ($parameter->getComplexType()) {
             $typesComplex->setComplex($this->_generateObject($parameter->getComplexType()));

--- a/src/WSDL/XML/Styles/TypesComplex.php
+++ b/src/WSDL/XML/Styles/TypesComplex.php
@@ -10,6 +10,7 @@ class TypesComplex
 {
     private $_name;
     private $_arrayType;
+    private $_arrayTypeName;
     private $_complex;
 
     public function setName($name)
@@ -43,5 +44,16 @@ class TypesComplex
     public function getComplex()
     {
         return $this->_complex;
+    }
+
+    public function setArrayTypeName($arrayTypeName)
+    {
+        $this->_arrayTypeName = $arrayTypeName;
+        return $this;
+    }
+
+    public function getArrayTypeName()
+    {
+        return $this->_arrayTypeName;
     }
 }

--- a/tests/Mocks/MockClass.php
+++ b/tests/Mocks/MockClass.php
@@ -63,4 +63,25 @@ class MockClass
     {
         return $wrap ? true : false;
     }
+
+    /**
+     * @return wrapper[] $mockUsers @className=\Mocks\MockUserWrapper
+     */
+    public function arrayOfMockUser() {
+        $mockUsers = array();
+
+        $o = new MockUserWrapper();
+        $o->id = 1;
+        $o->name = 'Fred';
+        $o->age = 20;
+        $mockUsers[] = $o;
+
+        $o = new MockUserWrapper();
+        $o->id = 2;
+        $o->name = 'Murray';
+        $o->age = 25;
+        $mockUsers[] = $o;
+
+        return $mockUsers;
+    }
 }

--- a/tests/src/WSDL/Parser/ClassParserTest.php
+++ b/tests/src/WSDL/Parser/ClassParserTest.php
@@ -20,7 +20,7 @@ class ClassParserTest extends PHPUnit_Framework_TestCase
         $classParser->parse();
 
         //then
-        $this->assertCount(3, $classParser->getMethods());
+        $this->assertCount(4, $classParser->getMethods());
     }
 
     /**
@@ -35,6 +35,6 @@ class ClassParserTest extends PHPUnit_Framework_TestCase
         $classParser->parse();
 
         //then
-        $this->assertCount(3, $classParser->getMethods());
+        $this->assertCount(4, $classParser->getMethods());
     }
 }

--- a/tests/src/WSDL/Parser/MethodParserTest.php
+++ b/tests/src/WSDL/Parser/MethodParserTest.php
@@ -20,6 +20,7 @@ class MethodParserTest extends PHPUnit_Framework_TestCase
  * @desc Method to adding user
  * @param string $name
  * @param object $address @string=ip @string=mac
+ * @param wrapper[] $relatives @className=\Mocks\MockClass
  * @return bool $return
  */
 DOC;
@@ -35,7 +36,7 @@ DOC;
 
         //then
         $this->assertEquals('Method to adding user', $parser->description());
-        $this->assertCount(2, $parser->parameters());
+        $this->assertCount(3, $parser->parameters());
         $this->assertInstanceOf('WSDL\Types\Simple', $parser->returning());
         $this->assertEquals($this->_methodDoc, $parser->getDoc());
         $this->assertEquals($this->_methodName, $parser->getName());
@@ -50,7 +51,11 @@ DOC;
         $parser = new MethodParser($this->_methodName, $this->_methodDoc);
 
         //then
-        $this->assertEquals(array('string $name', 'object $address @string=ip @string=mac'), $parser->getRawParameters());
+        $this->assertEquals(array(
+            'string $name',
+            'object $address @string=ip @string=mac',
+            'wrapper[] $relatives @className=\Mocks\MockClass'
+        ), $parser->getRawParameters());
     }
 
     /**

--- a/tests/src/WSDL/Parser/ParameterParserTest.php
+++ b/tests/src/WSDL/Parser/ParameterParserTest.php
@@ -98,6 +98,23 @@ class ParameterParserTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldParseObjectWrapperArray()
+    {
+        //given
+        $parameter = 'wrapper[] $users @className=\Mocks\MockUserWrapper';
+        $parser = new ParameterParser($parameter);
+
+        //when
+        $parser->parse();
+
+        //then
+        $this->assertEquals('users', $parser->getName());
+        $this->assertEquals('MocksMockUserWrapper', $parser->getType());
+    }
+
+    /**
+     * @test
+     */
     public function shouldParseParams()
     {
         $array = array(

--- a/tests/src/WSDL/XML/XMLGeneratorTest.php
+++ b/tests/src/WSDL/XML/XMLGeneratorTest.php
@@ -70,8 +70,9 @@ class XMLGeneratorTest extends PHPUnit_Framework_TestCase
 
         //then
         $this->assertTag($matcher, $this->_XML, '', false);
-        $this->assertSelectCount('message', 6, $this->_XML);
-        $this->assertSelectCount('message part', 7, $this->_XML);
+        $this->assertSelectCount('message', 8, $this->_XML);
+        $this->assertSelectCount('message part', 8, $this->_XML);
+        $this->assertSelectCount('message[name=arrayOfMockUserResponse] part[name=mockUsers]', 1, $this->_XML);
     }
 
     /**
@@ -88,9 +89,9 @@ class XMLGeneratorTest extends PHPUnit_Framework_TestCase
 
         //then
         $this->assertTag($matcher, $this->_XML, '', false);
-        $this->assertSelectCount('portType operation', 3, $this->_XML);
-        $this->assertSelectCount('portType operation input', 3, $this->_XML);
-        $this->assertSelectCount('portType operation output', 3, $this->_XML);
+        $this->assertSelectCount('portType operation', 4, $this->_XML);
+        $this->assertSelectCount('portType operation input', 4, $this->_XML);
+        $this->assertSelectCount('portType operation output', 4, $this->_XML);
         $this->assertSelectCount('portType operation documentation', 1, $this->_XML);
     }
 
@@ -118,7 +119,7 @@ class XMLGeneratorTest extends PHPUnit_Framework_TestCase
 
         //then
         $this->assertTag($matcher, $this->_XML, '', false);
-        $this->assertSelectCount('binding operation', 6, $this->_XML);
+        $this->assertSelectCount('binding operation', 8, $this->_XML);
     }
 
     public function shouldPutNamespaceOnSoapBindBody()
@@ -248,5 +249,23 @@ class XMLGeneratorTest extends PHPUnit_Framework_TestCase
 
         //then
         $this->assertRegExp('/MocksMockUserWrapper.*name="id" type="xsd:int".*name="name" type="xsd:string".*name="age" type="xsd:int"/', $wsdl);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldGenerateTypes()
+    {
+        //given
+        $matcher = array(
+            'tag' => 'types',
+            'ancestor' => array('tag' => 'definitions'),
+        );
+
+        //then
+        $this->assertTag($matcher, $this->_XML, '', false);
+        $this->assertSelectCount('types complexType[name=MocksMockUserWrapper]', 1, $this->_XML);
+        $this->assertSelectCount('types element[name=MocksMockUserWrapper][type=ns:MocksMockUserWrapper]', 1, $this->_XML);
+        $this->assertSelectCount('types complexType[name=ArrayOfMockUsers] element[name=mockUser]', 1, $this->_XML);
     }
 }


### PR DESCRIPTION
Addresses issue #10
An alternative type syntax will be used for arrays of objects
that will assist PHP SoapServer to correctly generate the tags for the
array type and array items.
SoapServer needs to reference the WSDL for this to work properly.
