### PR TITLE
Update SOAPGenerator.php

### DIFF
--- a/src/WSDL/XML/SOAPGenerator.php
+++ b/src/WSDL/XML/SOAPGenerator.php
@@ -53,7 +53,7 @@ class SOAPGenerator
             }
             if ($type instanceof Object) {
                 $element = $DOMDocument->createElement($type->getName());
-                foreach ($type->getComplexType()->getComplexType() as $complexType) {
+                foreach ($type->getComplexType() as $complexType) {
                     $el = $DOMDocument->createElement($complexType->getName(), '?');
                     $element->appendChild($el);
                 }


### PR DESCRIPTION
The error "Call to a member function getComplexType() on a non-object" could be fixed by removing the duplicated call to the function "getComplexType()".
