### PR TITLE
Fixed error when consuming WSDL using Apache CXF

### DIFF
--- a/src/WSDL/WSDLCreator.php
+++ b/src/WSDL/WSDLCreator.php
@@ -53,6 +53,7 @@ class WSDLCreator
      * @var string
      */
     private $_locationSuffix;
+    private $_useMethodNamespace = true;
 
     public function __construct($class, $location, $locationSuffix = 'wsdl')
     {
@@ -74,7 +75,8 @@ class WSDLCreator
         header("Content-Type: text/xml");
         $xml = new XMLGenerator($this->_class, $this->_namespace, $this->_location);
         $xml
-            ->setWSDLMethods($this->_classParser->getMethods())
+            ->setWSDLMethods($this->_classParser->gtMethods())
+            ->useMethodNamespace($this->_useMethodNamespace)
             ->setBindingStyle($this->_bindingStyle)
             ->generate();
         $xml->render();
@@ -84,6 +86,12 @@ class WSDLCreator
     {
         $namespace = $this->_addSlashAtEndIfNotExists($namespace);
         $this->_namespace = $namespace;
+        return $this;
+    }
+
+    public function useMethodNamespace($useMethodNamespace)
+    {
+        $this->_useMethodNamespace = $useMethodNamespace;
         return $this;
     }
 

--- a/src/WSDL/WSDLCreator.php
+++ b/src/WSDL/WSDLCreator.php
@@ -75,7 +75,7 @@ class WSDLCreator
         header("Content-Type: text/xml");
         $xml = new XMLGenerator($this->_class, $this->_namespace, $this->_location);
         $xml
-            ->setWSDLMethods($this->_classParser->gtMethods())
+            ->setWSDLMethods($this->_classParser->getMethods())
             ->useMethodNamespace($this->_useMethodNamespace)
             ->setBindingStyle($this->_bindingStyle)
             ->generate();

--- a/src/WSDL/XML/Styles/DocumentLiteralWrapped.php
+++ b/src/WSDL/XML/Styles/DocumentLiteralWrapped.php
@@ -80,7 +80,9 @@ class DocumentLiteralWrapped extends Style
         $element = new TypesElement();
         $element->setName($method->getName() . 'Response');
         $returning = $method->returning();
-        $this->_generateElements($returning, $element);
+        if ($returning->getType() !== 'void') {
+            $this->_generateElements($returning, $element);
+        }
         return $element;
     }
 

--- a/src/WSDL/XML/XMLGenerator.php
+++ b/src/WSDL/XML/XMLGenerator.php
@@ -44,6 +44,7 @@ class XMLGenerator
     private $_location;
     private $_targetNamespace;
     private $_targetNamespaceTypes;
+    private $_useMethodNamespace = true;
     /**
      * @var DOMDocument
      */
@@ -103,6 +104,12 @@ class XMLGenerator
         return $this;
     }
 
+    public function useMethodNamespace($useMethodNamespace)
+    {
+        $this->_useMethodNamespace = $useMethodNamespace;
+        return $this;
+    }
+    
     public function generate()
     {
         $this->_definitions()
@@ -372,11 +379,14 @@ class XMLGenerator
         ));
         $bindingElement->appendChild($soapBindingElement);
 
+        $elementOptions = array(
+            'use' => $this->_bindingStyle->bindingUse(),
+        );
+        if ($this->_useMethodNamespace === true) {
+            $elementOptions['namespace'] = $this->_targetNamespace;
+        }
         foreach ($this->_WSDLMethods as $method) {
-            $soapBodyElement = $this->createElementWithAttributes('soap:body', array(
-                'use' => $this->_bindingStyle->bindingUse(),
-                'namespace' => $this->_targetNamespace
-            ));
+            $soapBodyElement = $this->createElementWithAttributes('soap:body', $elementOptions);
 
             if ($this->_bindingStyle instanceof \WSDL\XML\Styles\RpcEncoded) {
                 $encodingUri = $this->_createAttributeWithValue('encodingStyle', 'http://schemas.xmlsoap.org/soap/encoding/');


### PR DESCRIPTION
Fixed error when consuming WSDL using Apache CXF - Error: WSI-BP-1.0 R2716 violation: Operation 'courseList soapBody MUST NOT have namespace attribute.