### PR TITLE
switch from dev to 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=7.3",
     "ext-dom": "*",
-    "letsdrink/ouzo-goodies": "dev-master",
+    "letsdrink/ouzo-goodies": ^1.8.0",
     "doctrine/annotations": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=7.3",
     "ext-dom": "*",
     "letsdrink/ouzo-goodies": "dev-master",
-    "doctrine/annotations": "~1.7.0"
+    "doctrine/annotations": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.5.5",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=7.3",
     "ext-dom": "*",
-    "letsdrink/ouzo-goodies": ^1.8.0",
+    "letsdrink/ouzo-goodies": "^1.8.0",
     "doctrine/annotations": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=7.3",
     "ext-dom": "*",
     "letsdrink/ouzo-goodies": "dev-master",
-    "doctrine/annotations": "1.7.x-dev"
+    "doctrine/annotations": "~1.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.5.5",

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "php": ">=7.3",
     "ext-dom": "*",
     "letsdrink/ouzo-goodies": "^1.8.0",
-    "doctrine/annotations": "*"
+    "doctrine/annotations": "^1.10.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.5.5",
-    "scrutinizer/ocular": "~1.5.2",
-    "friendsofphp/php-cs-fixer": "~2.12.2"
+    "phpunit/phpunit": "^7.5.5",
+    "scrutinizer/ocular": "^1.5.2",
+    "friendsofphp/php-cs-fixer": "^2.12.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
I have switched from dev-1.7.x to 1.7.0 as it is the same version without any dev labels. Now only the letsdrink/ouzo-goodies ;-)