### PR TITLE
make possible to use higher version of php, then only 7.4 (so also 8.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": "^7.4",
+    "php": ">=7.4",
     "ext-dom": "*",
     "letsdrink/ouzo-goodies": "1.8.0",
     "doctrine/annotations": "1.13.2"


### PR DESCRIPTION
…0 and higher)


We use 8.0 in our stageing area and this works without any problems. ^7.4 prevent to use the 3.0.0, and we still need to be on our own fork...