### PR TITLE
Fix for php8.1 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=7.3",
     "ext-dom": "*",
-    "letsdrink/ouzo-goodies": "dev-master",
+    "letsdrink/ouzo-goodies": ^1.8.0",
     "doctrine/annotations": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=7.3",
     "ext-dom": "*",
     "letsdrink/ouzo-goodies": "dev-master",
-    "doctrine/annotations": "~1.7.0"
+    "doctrine/annotations": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.5.5",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=7.3",
     "ext-dom": "*",
-    "letsdrink/ouzo-goodies": ^1.8.0",
+    "letsdrink/ouzo-goodies": "^1.8.0",
     "doctrine/annotations": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
   "require": {
     "php": ">=7.3",
     "ext-dom": "*",
-    "letsdrink/ouzo-goodies": "^1.8.0",
-    "doctrine/annotations": "^1.10.3"
+    "letsdrink/ouzo-goodies": "dev-master",
+    "doctrine/annotations": "1.7.x-dev"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5.5",
-    "scrutinizer/ocular": "^1.5.2",
-    "friendsofphp/php-cs-fixer": "^2.12.2"
+    "phpunit/phpunit": "~7.5.5",
+    "scrutinizer/ocular": "~1.5.2",
+    "friendsofphp/php-cs-fixer": "~2.12.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=7.3",
     "ext-dom": "*",
     "letsdrink/ouzo-goodies": "dev-master",
-    "doctrine/annotations": "1.7.x-dev"
+    "doctrine/annotations": "~1.7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.5.5",

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "php": ">=7.3",
     "ext-dom": "*",
     "letsdrink/ouzo-goodies": "^1.8.0",
-    "doctrine/annotations": "*"
+    "doctrine/annotations": "^1.10.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.5.5",
-    "scrutinizer/ocular": "~1.5.2",
-    "friendsofphp/php-cs-fixer": "~2.12.2"
+    "phpunit/phpunit": "^7.5.5",
+    "scrutinizer/ocular": "^1.5.2",
+    "friendsofphp/php-cs-fixer": "^2.12.2"
   },
   "autoload": {
     "psr-4": {

--- a/src/WSDL/Lexer/Tokenizer.php
+++ b/src/WSDL/Lexer/Tokenizer.php
@@ -54,7 +54,7 @@ final class Tokenizer
         $offset = 0;
         while (isset($string[$offset])) {
             foreach (self::$tokenMap as $regex => $token) {
-                if (preg_match($regex, $string, $matches, null, $offset)) {
+                if (preg_match($regex, $string, $matches, 0, $offset)) {
                     $tokens[] = TokenObject::create($token, trim($matches[0]));
                     $offset += strlen($matches[0]);
                     continue 2;


### PR DESCRIPTION
null is not allowed any more in php8.1:

https://www.php.net/releases/8.1/en.php
> Passing null to non-nullable internal function parameters is deprecated.